### PR TITLE
Feat: Rework Pick-up system

### DIFF
--- a/Assets/Resources/Configs/Creep/Creep1Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep1Config.asset
@@ -20,5 +20,5 @@ MonoBehaviour:
   dropItemConfigs:
   - powerUpType: 0
     dropChance: 0
-  - powerUpType: 2
+  - powerUpType: 0
     dropChance: 1

--- a/Assets/Resources/Configs/Creep/Creep2Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep2Config.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   dropItemConfigs:
   - powerUpType: 0
     dropChance: 0
-  - powerUpType: 2
+  - powerUpType: 0
     dropChance: 1
   bulletConfig: {fileID: 11400000, guid: 6a1dae1fb069c1945bd6abbed9c0dea7, type: 2}
   fireRate: 5

--- a/Assets/Resources/Configs/Creep/Creep3Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep3Config.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   dropItemConfigs:
   - powerUpType: 0
     dropChance: 0
-  - powerUpType: 2
+  - powerUpType: 0
     dropChance: 1
   bulletConfig: {fileID: 11400000, guid: 5a6237f2bc2e34c489335df2f29de9fe, type: 2}
   fireRate: 7

--- a/Assets/Resources/Configs/Creep/Creep4Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep4Config.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   dropItemConfigs:
   - powerUpType: 0
     dropChance: 0
-  - powerUpType: 2
+  - powerUpType: 0
     dropChance: 1
   startIncreaseSpeedDis: 5
   speedMultiplayer: 1.5

--- a/Assets/Resources/Configs/Creep/Creep5Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep5Config.asset
@@ -15,12 +15,11 @@ MonoBehaviour:
   creepPrefab: {fileID: 8987020003840325061, guid: 1fb6f03a381e7b043be0f11819f7be4b, type: 3}
   baseHp: 50
   baseSpeed: 3
-  baseDmg: 15
+  baseDmg: 1
   exp: 100
   dropItemConfigs:
   - powerUpType: 0
     dropChance: 0
-  - powerUpType: 2
+  - powerUpType: 0
     dropChance: 1
-  bombPrefab: {fileID: 4901116006423645643, guid: 3ecd94f95cd54a04983fa6cbf5374f55, type: 3}
-  timeToExplode: 2
+  explosion: {fileID: 1535640691960112, guid: b345030ffc29a664cad1d2a6e384a252, type: 3}

--- a/Assets/Resources/Configs/Creep/Creep6Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep6Config.asset
@@ -17,12 +17,10 @@ MonoBehaviour:
   baseSpeed: 2
   baseDmg: 10
   exp: 20
-  dropItemTypes: 04000000
-  skillCD: 10
-  meteor: {fileID: 1839445213900760, guid: 23f972538c5ab5b4f94000c5657b9754, type: 3}
   dropItemConfigs:
   - powerUpType: 0
     dropChance: 0
-  - powerUpType: 2
+  - powerUpType: 0
     dropChance: 1
   skillCD: 7
+  meteor: {fileID: 1839445213900760, guid: 23f972538c5ab5b4f94000c5657b9754, type: 3}

--- a/Assets/Resources/Configs/Creep/Creep7Config.asset
+++ b/Assets/Resources/Configs/Creep/Creep7Config.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   dropItemConfigs:
   - powerUpType: 0
     dropChance: 0
-  - powerUpType: 2
+  - powerUpType: 0
     dropChance: 1
   startMoveAwayDistance: 5
   healing: {fileID: 9017484664307500583, guid: 016eb712ee010394aa2dd710d9003fc6, type: 3}

--- a/Assets/Scripts/Config/PowerUps/DmgBoost.cs
+++ b/Assets/Scripts/Config/PowerUps/DmgBoost.cs
@@ -10,7 +10,17 @@ public class DmgBoost : PowerUpsConfig
         Debug.Log("DMG Boost pickup");
         var player = AllManager.Instance().playerManager.dictPlayers[Player_ID.MyPlayerID];
         player.SetDamageBoost(boostAmount);
-        player.dmgBoostTime = 15f;
+        player.dmgBoostTime = duration;
         //TODO: Activate UI show Boost
+    }
+    public override void ApplyEffect()
+    {
+        Debug.Log("DMG Boost apply effect");
+    }
+    public override void Deactivate()
+    {
+        Debug.Log("DMG Boost deactivate");
+        var player = AllManager.Instance().playerManager.dictPlayers[Player_ID.MyPlayerID];
+        player.SetDamageBoost(1);
     }
 }

--- a/Assets/Scripts/Config/PowerUps/PowerUpsConfig.cs
+++ b/Assets/Scripts/Config/PowerUps/PowerUpsConfig.cs
@@ -14,4 +14,12 @@ public class PowerUpsConfig : ScriptableObject
     {
 
     }
+    public virtual void ApplyEffect()
+    {
+
+    }
+    public virtual void Deactivate()
+    {
+
+    }
 }

--- a/Assets/Scripts/GamePlay/PlayerManager.cs
+++ b/Assets/Scripts/GamePlay/PlayerManager.cs
@@ -15,7 +15,6 @@ public class Player
     public PlayerConfig playerConfig;
     public GameObject levelUpEffect;
     //Player stat 
-
     public int health;
     public float lifeSteal;
     public float speed;
@@ -24,6 +23,8 @@ public class Player
     public float dmgBoostAmount;
     public float speedBoostTime = 0;
     public float speedBoostAmount;
+
+    private Dictionary<string, float> activePowerUps;
     
     public Player(string name, string id, int gunId, PlayerConfig config)
     {
@@ -36,14 +37,54 @@ public class Player
         this.speed = Constants.PlayerBaseSpeed;
         isDead = false;
         levelUpEffect = null;
+        activePowerUps = new Dictionary<string, float>();
     }
 
     public void Onstart()
     {
-        this.isDead = false;
         this.health = Constants.PlayerBaseMaxHealth;
         this.lifeSteal = Constants.LifeSteal;
         this.speed = Constants.PlayerBaseSpeed;
+        activePowerUps.Clear();
+    }
+    public void AddPowerUp(string powerUpName, float duration)
+    {
+        if (activePowerUps.ContainsKey(powerUpName))
+        {
+            activePowerUps[powerUpName] = duration; // Reset the duration if already active
+            Debug.Log($"Resetting power-up: {powerUpName}");
+        }
+        else
+        {
+            activePowerUps.Add(powerUpName, duration);
+            Debug.Log($"Activating power-up: {powerUpName}");
+        }
+    }
+    public void UpdatePowerUps()
+    {
+        List<string> expiredPowerUps = new List<string>();
+
+        foreach (var powerUp in activePowerUps.Keys.ToList())
+        {
+            activePowerUps[powerUp] -= Time.deltaTime;
+            Debug.Log($"Power-up: {powerUp} has {activePowerUps[powerUp]}s left");
+            if (activePowerUps[powerUp] <= 0)
+            {
+                expiredPowerUps.Add(powerUp);
+            }
+        }
+
+        foreach (var powerUp in expiredPowerUps)
+        {
+            DeactivatePowerUp(powerUp);
+            activePowerUps.Remove(powerUp);
+        }
+    }
+
+    private void DeactivatePowerUp(string powerUpName)
+    {
+        Debug.Log($"Deactivating power-up: {powerUpName}");
+        AllManager.Instance().powerUpManager.DeactivatePowerUp(powerUpName);
     }
     public void SetDamageBoost(float boostAmount)
     {
@@ -55,10 +96,6 @@ public class Player
         playerTrans.gameObject.GetComponent<CharacterControl>().speed = this.speed;
         
     }
-    // public void SetExpBoost(float boostAmount)
-    // {
-    //     this.expBoostAmount = boostAmount;
-    // }
     public void ProcessDmg(int dmg)
     {
         health -= dmg;

--- a/Assets/Scripts/GamePlay/PowerUpCollision.cs
+++ b/Assets/Scripts/GamePlay/PowerUpCollision.cs
@@ -12,7 +12,8 @@ public class PowerUpCollision : MonoBehaviour
             PowerUpManager powerUpManager = AllManager.Instance().powerUpManager;
             if (powerUpManager != null)
             {
-                powerUpManager.ActivatePowerUp(powerUpType);
+                string playerId = other.GetComponent<CharacterControl>().id;
+                powerUpManager.ApplyPowerUp(playerId, powerUpType);
                 Destroy(gameObject); 
             }
         }

--- a/Assets/Scripts/GamePlay/PowerUpManager.cs
+++ b/Assets/Scripts/GamePlay/PowerUpManager.cs
@@ -45,6 +45,7 @@ public class PowerUpManager
         {
             powerUpInfoList[i].Update();
         }
+        UpdatePlayerPowerUps();
     }
 
     public void LateUpdate()
@@ -70,10 +71,32 @@ public class PowerUpManager
         PowerUpInfo newPowerUp = new PowerUpInfo(powerUpObj, powerUpAttr.powerUpConfig.timeToLive);
         powerUpInfoList.Add(newPowerUp);
     }
-    public void ActivatePowerUp(AllDropItemConfig.PowerUpsType powerUpType)
+    // public void ActivatePowerUp(AllDropItemConfig.PowerUpsType powerUpType)
+    // {
+    //     var powerUpAttr = allDropItemConfig.powerUpAttributesList.Find(attr => attr.type == powerUpType);
+    //     powerUpAttr.powerUpConfig.Activate();
+    // }
+    public void ApplyPowerUp(string playerId, AllDropItemConfig.PowerUpsType powerUpType)
     {
         var powerUpAttr = allDropItemConfig.powerUpAttributesList.Find(attr => attr.type == powerUpType);
+        Player player = AllManager.Instance().playerManager.dictPlayers[playerId];
+        
         powerUpAttr.powerUpConfig.Activate();
+        player.AddPowerUp(powerUpType.ToString(), powerUpAttr.powerUpConfig.duration);
+    }
+
+    public void DeactivatePowerUp(string powerUpName)
+    {
+        var powerUpAttr = allDropItemConfig.powerUpAttributesList.Find(attr => attr.type.ToString() == powerUpName);
+        powerUpAttr?.powerUpConfig.Deactivate();
+    }
+
+    public void UpdatePlayerPowerUps()
+    {
+        foreach (var player in AllManager.Instance().playerManager.dictPlayers.Values)
+        {
+            player.UpdatePowerUps();
+        }
     }
     public void setDeletePowerUp(int index)
     {

--- a/Assets/Scripts/Server/SocketCommunication.cs
+++ b/Assets/Scripts/Server/SocketCommunication.cs
@@ -246,6 +246,7 @@ public class SocketCommunication
 
             }
 
+            // Debug.Log(response);
             //remove processed data from buffer
             buffer.RemoveRange(0, 4 + dataLength);
             //Debug.Log(response);


### PR DESCRIPTION
## Descriptions:
- Rework the powerup (now: pick-up) system.
- Now, each Player will have a separate pick-up dictionary and the power-up manager will manage them.

## Motivation:
- To encapsulate each config so that whenever we want to add new pick-ups, we do not need to update existing code.

## Testing Done:
- Testing on the DMG Boost config. The DMG Boost activate when get picked up, last for the duration, refresh when another DMG Boost get picked up again, de-activate when run out of duration